### PR TITLE
fix(ui): revert back some icon and submenu components

### DIFF
--- a/src/Icon/IconHeader/icon-header.scss
+++ b/src/Icon/IconHeader/icon-header.scss
@@ -1,0 +1,142 @@
+@import '../../global-sass-files/variables';
+@import '../../global-sass-files/mixins';
+
+// Icons generated
+@font-face {
+  font-family: 'icomoon';
+  src:  url('../../global-sass-files/fonts/icomoon.eot');
+  src:  url('../../global-sass-files/fonts/icomoon.eot') format('embedded-opentype'),
+    url('../../global-sass-files/fonts/icomoon.ttf') format('truetype'),
+    url('../../global-sass-files/fonts/icomoon.woff') format('woff'),
+    url('../../global-sass-files/fonts/icomoon.svg') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+
+[class^="icon-"], [class*=" icon-"] {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'icomoon' !important;
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+
+.icon-home:before {
+  content: "\e904";
+  color: rgba(0, 159, 152, 1);
+}
+.icon-home:hover:before {
+  content: "\e904";
+  color: $white-color;
+}
+
+.icon-monitoring:before {
+  content: "\e907";
+  color: rgba(136, 189, 35, 1);
+}
+.icon-monitoring:hover:before {
+  content: "\e907";
+  color: $white-color;
+}
+
+.icon-reporting:before {
+  content: "\e909";
+  color: rgba(255, 162, 0, 1);
+}
+.icon-reporting:hover:before {
+  content: "\e909";
+  color: $white-color;
+}
+
+.icon-configuration:before {
+  content: "\e902";
+  color: rgba(0, 159, 233, 1);
+}
+.icon-configuration:hover:before {
+  content: "\e902";
+  color: $white-color;
+}
+
+.icon-administration:before {
+  content: "\e900";
+  color: rgba(43, 45,132, 1);
+}
+.icon-administration:hover:before {
+  content: "\e900";
+  color: $white-color;
+}
+
+.icon-poller:before {
+  content: "\e908";
+  color: $white-color;
+}
+
+.icon-link:before {
+  content: "\e906";
+  color: #232f39;
+}
+
+.icon-clock:before {
+  content: "\e901";
+  color: #232f39;
+}
+
+.icon-database:before {
+  content: "\e903";
+  color: #232f39;
+}
+
+.icon-hosts:before {
+  content: "\e905";
+  color: $white-color;
+}
+
+.icon-services:before {
+  content: "\e90a";
+  color: $white-color;
+}
+
+.icon-top-counter:before {
+  content: "\e90e";
+  color: $white-color;
+}
+
+.icon-user:before {
+  content: "\e90b";
+  color: $white-color;
+}
+
+.iconmoon {
+  display: block;
+  text-align: center;
+  height: 26px;
+  @include iconmoon();
+  &:before {
+    font-size: 24px;
+  }
+}
+.icons {
+  &-wrap {
+    margin-right: 6px;
+    cursor: pointer;
+    position: relative;
+    height: 39px;
+  }
+}
+.icons {
+  &__name {
+    display: block;
+    font-size: .6875rem;
+    color: $white-color;
+    font-family: $primary-font-light !important;
+    text-transform: lowercase;
+  }
+}

--- a/src/Icon/IconHeader/index.js
+++ b/src/Icon/IconHeader/index.js
@@ -1,0 +1,25 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import classnames from 'classnames';
+import styles from './icon-header.scss';
+
+const IconHeader = ({ iconType, iconName, style, onClick, children }) => {
+  return (
+    <span className={classnames(styles['icons-wrap'])} style={style}>
+      <span
+        onClick={onClick}
+        className={classnames(styles.iconmoon, {
+          [styles[`icon-${iconType}`]]: true,
+        })}
+      />
+      <span className={classnames(styles.icons__name)}>{iconName}</span>
+      {children}
+    </span>
+  );
+};
+
+export default IconHeader;

--- a/src/Icon/IconNumber/icon-number.scss
+++ b/src/Icon/IconNumber/icon-number.scss
@@ -1,0 +1,78 @@
+@import '../../global-sass-files/variables';
+
+// Icon number
+.icons {
+  &-number {
+    font-size: .875rem;
+    padding: 0px 5px;
+    position: relative;
+    color: $white-color;
+    font-family: $primary-font-bold;
+    overflow: hidden;
+    text-align: center;
+    min-width: 32px;
+    height: 32px;
+    border-radius: 50px;
+    margin: 0 6px;
+    box-sizing: border-box;
+    text-decoration: none;
+    cursor: pointer;
+    display: inline-block;
+    &.bordered {
+      &.red {
+        border: 2px solid #ed1c24;
+      }
+      &.gray-dark {
+        border: 2px solid #818185;
+      }
+      &.gray-light {
+        border: 2px solid #cdcdcd;
+      }
+      &.green {
+        border: 2px solid #87bd23;
+      }
+      &.orange {
+        border: 2px solid #ff9913;
+      }
+      &.blue {
+        border: 2px solid #2ad1d4;
+      }
+    }
+    &.colored {
+      &.red {
+        background-color: #ed1c24;
+      }
+      &.gray-dark {
+        background-color: #818185;
+      }
+      &.gray-light {
+        background-color: #cdcdcd;
+      }
+      &.green {
+        background-color: #87bd23;
+      }
+      &.orange {
+        background-color: #ff9913;
+      }
+      &.blue {
+        background-color: #2ad1d4;
+      }
+      .number-count {
+        line-height: 32px;
+      }
+    }
+  }
+  .number {
+    &-wrap {
+      font-size: 0.875rem;
+      font-family: $primary-font-bold;
+      position: relative;
+      text-decoration: none;
+    }
+    &-count {
+      line-height: 32px;
+      color: $white-color;
+      font-family: $primary-font-bold !important;
+    }
+  }
+}

--- a/src/Icon/IconNumber/index.js
+++ b/src/Icon/IconNumber/index.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import classnames from 'classnames';
+import styles from './icon-number.scss';
+
+const IconNumber = ({ iconColor, iconType, iconNumber }) => {
+  return (
+    <span
+      className={classnames(
+        styles.icons,
+        styles['icons-number'],
+        styles[iconType],
+        styles[iconColor],
+        styles['number-wrap'],
+      )}
+    >
+      <span className={classnames(styles['number-count'])}>{iconNumber}</span>
+    </span>
+  );
+};
+
+export default IconNumber;

--- a/src/Submenu/SubmenuHeader/SubmenuItem/index.js
+++ b/src/Submenu/SubmenuHeader/SubmenuItem/index.js
@@ -1,0 +1,35 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable react/prop-types */
+/* eslint-disable react/prefer-stateless-function */
+
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import styles from '../submenu.scss';
+
+class SubmenuItem extends Component {
+  render() {
+    const { dotColored, submenuTitle, submenuCount } = this.props;
+    return (
+      <li className={classnames(styles['submenu-item'])}>
+        <span
+          className={classnames(styles['submenu-item-title'], {
+            [styles['submenu-item-dotted']]: !!dotColored,
+          })}
+        >
+          <span
+            className={classnames(
+              styles['submenu-item-dot'],
+              styles[`dot-${dotColored}`],
+            )}
+          />
+          {submenuTitle}
+        </span>
+        <span className={classnames(styles['submenu-item-count'])}>
+          {submenuCount}
+        </span>
+      </li>
+    );
+  }
+}
+
+export default SubmenuItem;

--- a/src/Submenu/SubmenuHeader/SubmenuItems/index.js
+++ b/src/Submenu/SubmenuHeader/SubmenuItems/index.js
@@ -1,0 +1,16 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable react/prop-types */
+/* eslint-disable react/prefer-stateless-function */
+
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import styles from '../submenu.scss';
+
+class SubmenuItems extends Component {
+  render() {
+    const { children } = this.props;
+    return <ul className={classnames(styles['submenu-items'])}>{children}</ul>;
+  }
+}
+
+export default SubmenuItems;

--- a/src/Submenu/SubmenuHeader/index.js
+++ b/src/Submenu/SubmenuHeader/index.js
@@ -1,0 +1,26 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable react/prop-types */
+/* eslint-disable react/prefer-stateless-function */
+
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import styles from './submenu.scss';
+
+class SubmenuHeader extends Component {
+  render() {
+    const { submenuType, children, active, ...props } = this.props;
+
+    return (
+      <div
+        className={classnames(styles[`submenu-${submenuType}`], {
+          [styles['submenu-active']]: !!active,
+        })}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+}
+
+export default SubmenuHeader;

--- a/src/Submenu/SubmenuHeader/submenu.scss
+++ b/src/Submenu/SubmenuHeader/submenu.scss
@@ -1,0 +1,195 @@
+@import '../../global-sass-files/variables';
+
+// Submenu
+.submenu {
+  &-top, &-bottom {
+    display: flex;
+  }
+  &-top {
+    position: relative;
+    padding: 6px 20px 7px 20px;
+    flex-wrap: wrap;
+    align-items: center;
+    background-color: #232f39;
+    .icons-toggle-arrow {
+      position: absolute;
+    }
+  }
+  &-toggle {
+    display: none;
+  }
+  &-items {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  &-item {
+    position: relative;    
+    width: 100%;
+    float: left;
+    display: block;
+    &-count {
+      float: right;
+      padding: 10px;
+      font-family: $primary-font-light;
+      color: $white-color;
+      font-size: .8rem;
+      text-decoration: none;
+      position: absolute;
+      right: 0;
+    }
+    &-title {
+      position: relative;
+      float: left;
+      padding: 10px;
+      font-family: $primary-font-light;
+      color: $white-color;
+      font-size: .8rem;
+      text-decoration: none;
+      display: block;
+      padding-left: 10px;
+    }
+    &-dotted {
+      padding-left: 22px;
+    }
+    &-dot {
+      position: absolute;
+      left: 10px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      top: 50%;
+      transform: translateY(-50%);
+      &.dot-red {
+        background-color: #ed1b23;
+      }
+      &.dot-orange {
+        background-color: #ffa125;
+      }
+      &.dot-gray {
+        background-color: #818185;
+      }
+      &.dot-gray-light {
+        background-color: #cdcdcd;
+      }
+      &.dot-green {
+        background-color: #87bd23;
+      }
+      &.dot-blue {
+        background-color: #2ad1d4;
+      }
+    }
+  }
+  &-toggle {
+    position: absolute;
+    left: 0px;
+    background-color: #232f39;
+    padding: 10px;
+    top: 100%;
+    z-index: 99;
+    box-sizing: border-box;
+    // display: none;
+    text-align: left;
+    width: 100%;
+  }
+  &-active {
+    background-color: #000915;
+    .icons-toggle-arrow {
+      transform: rotateZ(180deg);
+    }
+    .submenu-toggle {
+      display: block;
+    }
+  }
+  &-header {
+    .profile {
+      &-user {
+        &-type, &-edit, &-name {
+          font-family: $primary-font-light;
+          color: $white-color;
+          text-decoration: none;
+          font-size: .8rem;
+        }
+        &-type {
+          display: inline-block;
+          width: 51%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        &-edit {
+          margin-left: 4px;
+          float: right;
+          text-decoration: underline;
+        }
+        &-name {
+          display: block;
+          margin-bottom: 10px;
+        }
+        &-button {
+          font-size: .785rem;
+          color: #ffa225;
+          text-decoration: none;
+          font-family: $primary-font-light;
+          text-align: left;
+          border-radius: 16px;
+          border: 1px solid rgba(255, 161, 37, 1);
+          background-color: transparent;
+          display: block;
+          width: 100%;
+          outline: none;
+          position: relative;
+          padding: 5px 27px 5px 10px;
+          box-sizing: border-box;
+          &:hover {
+            color: rgb(0,9,22);
+            background-color: rgba(255, 161, 37, 1);
+            .btn-logout-icon, .icon-copied {
+              &:before {
+                color: rgba(0, 9, 21, 1);
+              }
+            }
+          }
+          span:first-child {
+            line-height: 17px;
+            display: block;
+          }
+        }
+      }
+      &-bookmark-link {
+        margin: 14px 9px 13px;
+        width: 62%;
+        border: 1px solid #bcbdc0;
+        padding: 7px 6px;
+        border-radius: 3px;
+        outline: none;
+        box-sizing: border-box;
+      }
+    }
+    .btn-logout-icon {
+      width: 19px;
+      height: 19px;
+      position: absolute;
+      right: 9px;
+      top: 50%;
+      transform: translateY(-50%);
+      &:before {
+        content: "\e90d";
+        color: rgba(255, 161, 37, 1);
+        font-size: 19px;
+      }
+      &.icon-copied {
+        &:before {
+          content: "\e90c";
+          color: rgba(0, 9, 21, 1);
+          color: rgba(255, 161, 37, 1);
+        }
+      }
+    }
+    .button-wrap {
+      .btn {
+        margin-top: 10px;
+        float: right;
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -75,3 +75,9 @@ export { default as IconError } from './Icon/IconError';
 export { default as withErrorSnackbar } from './Snackbar/Error/withErrorSnackbar';
 export { default as useErrorSnackbar } from './Snackbar/Error/useErrorSnackbar';
 export { default as SaveButton } from './Button/Save';
+
+export { default as IconHeader } from './Icon/IconHeader';
+export { default as IconNumber } from './Icon/IconNumber';
+export { default as SubmenuHeader } from './Submenu/SubmenuHeader';
+export { default as SubmenuItems } from './Submenu/SubmenuHeader/SubmenuItems';
+export { default as SubmenuItem } from './Submenu/SubmenuHeader/SubmenuItem';


### PR DESCRIPTION
This PR reverts back IconHeader, IconNumber, SubmenuItem, SubmenuItems and SubmenuHeader components from #152 because there are still used by centreon and centreon-bam.