### PR TITLE
fix(textfield): avoid double underline on textfield

### DIFF
--- a/src/InputField/TextField/index.jsx
+++ b/src/InputField/TextField/index.jsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles((theme) => ({
   root: {
     backgroundColor: theme.palette.common.white,
     border: `1px solid ${theme.palette.grey[400]}`,
+    borderBottom: 0,
   },
   input: {
     paddingLeft: 8,


### PR DESCRIPTION
Avoid to get double underline (blue line + input border bottom)

new style :
![image](https://user-images.githubusercontent.com/11978823/72053947-550d3b80-32c8-11ea-9116-23879698e924.png)
