### PR TITLE
chore(config): Adapt centreon-ui for treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@centreon/ui",
   "version": "20.4.0",
   "description": "Centreon UI Components",
-  "main": "lib",
+  "main": "src",
   "scripts": {
     "eslint": "eslint . --ext .js,.jsx",
     "eslint:fix": "npm run eslint -- --fix",
@@ -13,6 +13,7 @@
     "build:storybook": "build-storybook -c .storybook -o .out",
     "test": "jest"
   },
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/centreon/centreon-ui.git"

--- a/src/Icon/IconInfo/index.js
+++ b/src/Icon/IconInfo/index.js
@@ -5,7 +5,12 @@ import React from 'react';
 import classnames from 'classnames';
 import styles from './info-state-icon.scss';
 
-const IconInfo = ({ iconName, iconText, iconColor, iconPosition }) => {
+const IconInfo = ({
+  iconText,
+  iconName = null,
+  iconColor = null,
+  iconPosition = null,
+}) => {
   const cn = classnames(
     styles.info,
     { [styles[`info-${iconName}`]]: true },

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export { default as IconContent } from './Icon/IconContent';
 export { default as IconInfo } from './Icon/IconInfo';
 export { default as IconToggleSubmenu } from './Icon/IconToggleSubmenu';
 export { default as InputField } from './InputField';
-export { default as InputFieldSelectCustom } from './InputField/InputFieldSelectCustom';
+export { default as InputFieldSelect } from './InputField/InputFieldSelectCustom';
 export { default as InputFieldSelectTableCell } from './InputField/InputFieldSelectTableCell';
 export { default as InputFieldTableCell } from './InputField/InputFieldTableCell';
 export { default as SearchInput } from './InputField/SearchInput';
@@ -60,7 +60,7 @@ export { default as CheckboxDefault } from './Checkbox';
 export { default as IconAttach } from './Icon/IconAttach';
 export { default as IconEdit } from './Icon/IconEdit';
 export { default as IconCloseNew } from './Icon/IconClose2';
-export { default as MaterialSwtich } from './Switch';
+export { default as MaterialSwitch } from './Switch';
 
 export { default as TABLE_COLUMN_TYPES } from './Listing/ColumnTypes';
 export { default as Tooltip } from './Tooltip';
@@ -80,3 +80,7 @@ export { default as IconNumber } from './Icon/IconNumber';
 export { default as SubmenuHeader } from './Submenu/SubmenuHeader';
 export { default as SubmenuItems } from './Submenu/SubmenuHeader/SubmenuItems';
 export { default as SubmenuItem } from './Submenu/SubmenuHeader/SubmenuItem';
+
+export { default as MultiSelectContainer } from './MultiSelectHolder/MultiSelectContainer';
+export { default as RightPanel } from './RightPanel';
+export { default as InputFieldSearch } from './InputField/SearchInput';


### PR DESCRIPTION
**/!\ This is a breaking change /!\**

this allows the import of centreon-ui using the treeshaking algorithm of webpack. 

To apply these changes within a module, the following steps need to be done:
- the babel config file must be updated with the following parameter for @babel/breset-env:
```
  presets: [
    ...,
    [
	'@babel/preset-env',
          {
             modules: false,
	  },
     ],
  ]
```
if the following setting:
```
  optimization: {
    sideEffects: false,
  }
```

is set in the webpack config file, it must be removed. 

The individual module import won't work anymore, and must be updated using the following pattern:
```
  // old
  import Dialog from '@centreon/ui/Dialog';

  // new
  import { Dialog } from '@centreon/ui';
``` 

This works for @material/ui too, and all packages exporting their modules using the ES format. 