### PR TITLE
fix(UI): Add initial value to hovered state on listing table

### DIFF
--- a/src/Listing/index.tsx
+++ b/src/Listing/index.tsx
@@ -134,7 +134,7 @@ const Listing = ({
   sortf = undefined,
 }: Props): JSX.Element => {
   const [tableTopOffset, setTableTopOffset] = useState(0);
-  const [hovered, setHovered] = useState();
+  const [hovered, setHovered] = useState(null);
 
   const tableBody = useRef<Element>();
 


### PR DESCRIPTION
This PR fixes storybook build and production build when centreon-ui is used by a module