### PR TITLE
enh(ui): Center Snackbar message

### DIFF
--- a/src/Snackbar/index.tsx
+++ b/src/Snackbar/index.tsx
@@ -22,6 +22,11 @@ const useStyles = makeStyles<PropsStyle>({
   alertIcon: {
     paddingTop: '10px',
   },
+  message: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+  },
 });
 
 interface Props {
@@ -52,7 +57,7 @@ const Snackbar = ({ message, open, onClose, severity }: Props): JSX.Element => {
             <IconClose className={classes.closeIcon} />
           </IconButton>,
         ]}
-        classes={{ icon: classes.alertIcon }}
+        classes={{ icon: classes.alertIcon, message: classes.message }}
       >
         {message}
       </Alert>


### PR DESCRIPTION
# Description
The snackbar message seems off in the Events view page. This PR centers it vertically. 

Before the fix: 
![Screenshot from 2020-04-16 16-27-53](https://user-images.githubusercontent.com/8367233/79471558-1263a980-8003-11ea-97ad-9fc48a21a06e.png)

After the fix:
![Screenshot from 2020-04-16 16-54-50](https://user-images.githubusercontent.com/8367233/79471584-18598a80-8003-11ea-99ce-4e306c697aa4.png)

