### PR TITLE
Disable all action bar buttons on error

### DIFF
--- a/src/Wizard/ActionBar.jsx
+++ b/src/Wizard/ActionBar.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const ActionBar = ({
-  disabledNext,
+  disabledActionBar,
   page,
   isLastPage,
   onCancel,
@@ -52,7 +52,12 @@ const ActionBar = ({
 
       <Grid item>
         {page > 0 && (
-          <Button type="button" color="primary" onClick={onPrevious}>
+          <Button
+            type="button"
+            color="primary"
+            onClick={onPrevious}
+            disabled={disabledActionBar}
+          >
             {labelPrevious}
           </Button>
         )}
@@ -61,7 +66,7 @@ const ActionBar = ({
           <Button
             type="submit"
             color="primary"
-            disabled={disabledNext}
+            disabled={disabledActionBar}
             onClick={onFinish}
           >
             {labelFinish}
@@ -71,7 +76,7 @@ const ActionBar = ({
             type="submit"
             color="primary"
             onClick={onNext}
-            disabled={disabledNext}
+            disabled={disabledActionBar}
           >
             {labelNext}
           </Button>
@@ -82,7 +87,7 @@ const ActionBar = ({
 };
 
 ActionBar.propTypes = {
-  disabledNext: PropTypes.bool,
+  disabledActionBar: PropTypes.bool,
   page: PropTypes.number,
   isLastPage: PropTypes.bool,
   onCancel: PropTypes.func,
@@ -96,7 +101,7 @@ ActionBar.propTypes = {
 };
 
 ActionBar.defaultProps = {
-  disabledNext: false,
+  disabledActionBar: false,
   page: 0,
   isLastPage: true,
   onCancel: null,

--- a/src/Wizard/ActionBar.test.jsx
+++ b/src/Wizard/ActionBar.test.jsx
@@ -15,9 +15,11 @@ describe('ActionBar', () => {
     expect(mockCancel).toBeCalled();
   });
 
-  it('cannot finish if form is not valid', () => {
-    const { getByText } = render(<ActionBar disabledNext />);
+  it('cannot finish or go to previous step if form is not valid', () => {
+    const { getByText } = render(<ActionBar disabledActionBar page={1} />);
 
     expect(getByText('Finish').parentNode).toHaveAttribute('disabled');
+
+    expect(getByText('Previous').parentNode).toHaveAttribute('disabled');
   });
 });

--- a/src/Wizard/index.jsx
+++ b/src/Wizard/index.jsx
@@ -189,7 +189,7 @@ const Wizard = (props) => {
                   })}
                   {!activePage.props.noActionBar && (
                     <ActionBar
-                      disabledNext={disabledNext}
+                      disabledActionBar={disabledNext}
                       page={page}
                       isLastPage={isLastPage}
                       onPrevious={handlePrevious}

--- a/src/Wizard/index.stories.jsx
+++ b/src/Wizard/index.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Typography from '@material-ui/core/Typography';
+import { Typography } from '@material-ui/core';
 
 import { Wizard, WizardPage as Page } from '..';
 


### PR DESCRIPTION
This PR disables all action bar buttons (Previous, Next/Finish) where there is an error in current step form.