### PR TITLE
PoC(ts.data.json): Add decoder to request custom hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21473,6 +21473,11 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
     },
+    "ts.data.json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts.data.json/-/ts.data.json-1.1.0.tgz",
+      "integrity": "sha512-bdZJ19x6HVq7MTnCmSHDcOxipcVWhM8T86VaxScBd2awV/h1BW27iKL+DoFM4Nt5f9HUdp5V4IUGDHLrttLKyA=="
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -21571,6 +21576,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
+    },
+    "ulog": {
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/ulog/-/ulog-2.0.0-beta.7.tgz",
+      "integrity": "sha512-LvQY6j+CcIilySof66EMr8spdCBmsklAUmvqvCqjWAGiyY2f44MgUbLgGyT27YM35pj0lLZlkCnNn1CcmDGbhQ=="
     },
     "unbzip2-stream": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "react-files": "^2.4.8",
     "react-router-dom": "^5.1.2",
     "resize-observer-polyfill": "^1.5.1",
+    "ts.data.json": "^1.1.0",
+    "ulog": "^2.0.0-beta.7",
     "use-debounce": "^3.4.1"
   },
   "devDependencies": {

--- a/src/__mocks__/ulog.js
+++ b/src/__mocks__/ulog.js
@@ -1,0 +1,7 @@
+const mockedUlog = {
+  error: jest.fn(),
+};
+
+const ulog = () => mockedUlog;
+
+export default ulog;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,4 +3,31 @@ import axios from 'axios';
 const getData = <TData>(cancelToken) => (endpoint): Promise<TData> =>
   axios.get(endpoint, { cancelToken }).then(({ data }) => data);
 
-export { getData };
+const postData = <TData>(cancelToken) => ({
+  endpoint,
+  datas,
+}): Promise<TData> =>
+  axios
+    .post(endpoint, datas, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      cancelToken,
+    })
+    .then(({ data }) => data);
+
+const putData = <TData>(cancelToken) => ({ endpoint, datas }): Promise<TData> =>
+  axios
+    .put(endpoint, datas, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      cancelToken,
+    })
+    .then(({ data }) => data);
+
+const deleteData = <TData>(cancelToken) => (endpoint): Promise<TData> =>
+  axios
+    .delete(endpoint, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      cancelToken,
+    })
+    .then(({ data }) => data);
+
+export { getData, postData, putData, deleteData };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+const headers = { 'Content-Type': 'application/x-www-form-urlencoded' }
+
 const getData = <TData>(cancelToken) => (endpoint): Promise<TData> =>
   axios.get(endpoint, { cancelToken }).then(({ data }) => data);
 
@@ -9,7 +11,7 @@ const postData = <TData>(cancelToken) => ({
 }): Promise<TData> =>
   axios
     .post(endpoint, datas, {
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers,
       cancelToken,
     })
     .then(({ data }) => data);
@@ -17,7 +19,7 @@ const postData = <TData>(cancelToken) => ({
 const putData = <TData>(cancelToken) => ({ endpoint, datas }): Promise<TData> =>
   axios
     .put(endpoint, datas, {
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers,
       cancelToken,
     })
     .then(({ data }) => data);
@@ -25,7 +27,7 @@ const putData = <TData>(cancelToken) => ({ endpoint, datas }): Promise<TData> =>
 const deleteData = <TData>(cancelToken) => (endpoint): Promise<TData> =>
   axios
     .delete(endpoint, {
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers,
       cancelToken,
     })
     .then(({ data }) => data);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const headers = { 'Content-Type': 'application/x-www-form-urlencoded' }
+const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
 
 const getData = <TData>(cancelToken) => (endpoint): Promise<TData> =>
   axios.get(endpoint, { cancelToken }).then(({ data }) => data);

--- a/src/api/useRequest/index.test.ts
+++ b/src/api/useRequest/index.test.ts
@@ -61,7 +61,9 @@ describe(useRequest, () => {
     const { result } = renderUseRequest({ request, getErrorMessage });
 
     await act(async () => {
-      result.current.sendRequest();
+      result.current.sendRequest().catch((error) => {
+        expect(error).toEqual({});
+      });
     });
 
     expect(mockedShowMessage).toHaveBeenCalledWith({
@@ -71,21 +73,20 @@ describe(useRequest, () => {
   });
 
   it("shows an error via the Snackbar and inside browser's console using the error message from the API when available", async () => {
-    request.mockImplementation(() =>
-      jest.fn().mockRejectedValue({
-        response: { data: { message: 'failure' } },
-      }),
-    );
+    const response = {
+      response: { data: { message: 'failure' } },
+    };
+    request.mockImplementation(() => jest.fn().mockRejectedValue(response));
 
     const { result } = renderUseRequest({ request });
 
     await act(async () => {
-      result.current.sendRequest();
+      result.current.sendRequest().catch((error) => {
+        expect(error).toEqual(response);
+      });
     });
 
-    expect(ulog().error).toHaveBeenCalledWith({
-      response: { data: { message: 'failure' } },
-    });
+    expect(ulog().error).toHaveBeenCalledWith(response);
 
     expect(mockedShowMessage).toHaveBeenCalledWith({
       message: 'failure',
@@ -102,7 +103,9 @@ describe(useRequest, () => {
     });
 
     await act(async () => {
-      result.current.sendRequest();
+      result.current.sendRequest().catch((error) => {
+        expect(error).toEqual({});
+      });
     });
 
     expect(mockedShowMessage).toHaveBeenCalledWith({
@@ -121,7 +124,9 @@ describe(useRequest, () => {
     });
 
     await act(async () => {
-      result.current.sendRequest();
+      result.current.sendRequest().catch((error) => {
+        expect(error).toEqual({});
+      });
     });
 
     expect(mockedShowMessage).not.toHaveBeenCalled();

--- a/src/api/useRequest/index.test.ts
+++ b/src/api/useRequest/index.test.ts
@@ -7,7 +7,6 @@ import {
 import axios from 'axios';
 import ulog from 'ulog';
 
-import { waitFor } from '@testing-library/react';
 import useRequest, { RequestResult, RequestParams } from '.';
 import { Severity } from '../..';
 

--- a/src/api/useRequest/index.test.ts
+++ b/src/api/useRequest/index.test.ts
@@ -5,7 +5,9 @@ import {
 } from '@testing-library/react-hooks';
 
 import axios from 'axios';
+import ulog from 'ulog';
 
+import { waitFor } from '@testing-library/react';
 import useRequest, { RequestResult, RequestParams } from '.';
 import { Severity } from '../..';
 
@@ -69,7 +71,7 @@ describe(useRequest, () => {
     });
   });
 
-  it('shows an error via the Snackbar using the error message from the API when available', async () => {
+  it("shows an error via the Snackbar and inside browser's console using the error message from the API when available", async () => {
     request.mockImplementation(() =>
       jest.fn().mockRejectedValue({
         response: { data: { message: 'failure' } },
@@ -80,6 +82,10 @@ describe(useRequest, () => {
 
     await act(async () => {
       result.current.sendRequest();
+    });
+
+    expect(ulog().error).toHaveBeenCalledWith({
+      response: { data: { message: 'failure' } },
     });
 
     expect(mockedShowMessage).toHaveBeenCalledWith({

--- a/src/api/useRequest/index.ts
+++ b/src/api/useRequest/index.ts
@@ -63,10 +63,12 @@ const useRequest = <TResult>({
       .catch((error) => {
         log.error(error);
 
-        return cond([
+        cond([
           [axios.isCancel, T],
           [T, showErrorMessage],
         ])(error);
+
+        throw Error();
       })
       .finally(() => setSending(false));
   };

--- a/src/api/useRequest/index.ts
+++ b/src/api/useRequest/index.ts
@@ -68,7 +68,7 @@ const useRequest = <TResult>({
           [T, showErrorMessage],
         ])(error);
 
-        throw Error();
+        throw error;
       })
       .finally(() => setSending(false));
   };

--- a/src/api/useRequest/index.ts
+++ b/src/api/useRequest/index.ts
@@ -44,8 +44,6 @@ const useRequest = <TResult>({
       getErrorMessage,
     )(error);
 
-    log.error(message);
-
     showMessage({
       message,
       severity: Severity.error,
@@ -58,19 +56,18 @@ const useRequest = <TResult>({
     return request(token)(params)
       .then((data) => {
         if (decoder) {
-          return decoder.decodePromise(data).catch((decodeError) => {
-            log.error(decodeError);
-            throw Error();
-          });
+          return decoder.decodePromise(data);
         }
         return data;
       })
-      .catch((error) =>
-        cond([
+      .catch((error) => {
+        log.error(error);
+
+        return cond([
           [axios.isCancel, T],
           [T, showErrorMessage],
-        ])(error),
-      )
+        ])(error);
+      })
       .finally(() => setSending(false));
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export { default as StatusChip } from './StatusChip';
 export { SeverityCode, getStatusColors } from './StatusChip';
 
 export { default as useCancelTokenSource } from './api/useCancelTokenSource';
-export { getData } from './api';
+export { getData, postData, putData, deleteData } from './api';
 export { default as useRequest } from './api/useRequest';
 
 export { default as copyToClipboard } from './utils/copy';


### PR DESCRIPTION
This PR integrates JSON API decoder to request custom hook.
It also logs errors from API request and decoding using [ulog](https://github.com/Download/ulog)

This PR is related with https://github.com/centreon/centreon-autodiscovery/pull/258