### PR TITLE
fix(Select): Prevent onChange from being called when target value is undefined

### DIFF
--- a/src/InputField/Select/index.tsx
+++ b/src/InputField/Select/index.tsx
@@ -58,6 +58,16 @@ const SelectField = ({
 }: Props): JSX.Element => {
   const classes = useStyles();
 
+  const getOption = (id): SelectEntry => {
+    return options.find(propEq('id', id)) as SelectEntry;
+  };
+
+  const changeOption = (event) => {
+    if (!isNil(event.target.value)) {
+      onChange(event);
+    }
+  };
+
   return (
     <FormControl
       variant="filled"
@@ -76,12 +86,12 @@ const SelectField = ({
           ...inputProps,
         }}
         value={selectedOptionId}
-        onChange={onChange}
+        onChange={changeOption}
         disableUnderline
         fullWidth={fullWidth}
         displayEmpty
         renderValue={(id) => {
-          return options.find(propEq('id', id))?.name;
+          return getOption(id).name;
         }}
         {...props}
       >


### PR DESCRIPTION
This prevents an error from happening when an element of type "header" is clicked