### PR TITLE
[Soft breaking] enh(Listing/performance): Memoize Column Cell to spare renders on Listing update

### DIFF
--- a/src/Listing/ColumnCell.tsx
+++ b/src/Listing/ColumnCell.tsx
@@ -127,9 +127,52 @@ const ColumnCell = React.memo<Props>(
     return cellByColumnType[column.type]();
   },
   (prevProps, nextProps) => {
+    const previousColumn = prevProps.column;
+    const previousRow = prevProps.row;
+    const previousIsRowHovered = prevProps.isRowHovered;
+    const previousIsRowSelected = prevProps.isRowSelected;
+
+    const nextColumn = nextProps.column;
+    const nextRow = nextProps.row;
+    const nextIsRowHovered = nextProps.isRowHovered;
+    const nextIsRowSelected = nextProps.isRowSelected;
+
+    const previousDisplayedComponentId = previousColumn.getDisplayedComponentId?.(
+      previousIsRowHovered,
+    );
+    const nextDisplayedComponentId = nextColumn.getDisplayedComponentId?.(
+      nextIsRowHovered,
+    );
+
+    const previousFormattedString = previousColumn.getFormattedString?.(
+      previousRow,
+    );
+    const nextFormatttedString = nextColumn.getFormattedString?.(nextRow);
+
+    const previousColSpan = previousColumn.getColSpan?.(previousIsRowSelected);
+    const nextColSpan = nextColumn.getColSpan?.(nextIsRowSelected);
+
+    const previousTruncateCondition = previousColumn.getTruncateCondition?.(
+      previousIsRowSelected,
+    );
+    const nextTruncateCondition = nextColumn.getTruncateCondition?.(
+      nextIsRowSelected,
+    );
+
+    const previousHiddenCondition = previousColumn.getHiddenCondition?.(
+      previousIsRowSelected,
+    );
+    const nextHiddenCondition = nextColumn.getHiddenCondition?.(
+      nextIsRowSelected,
+    );
+
     return (
-      equals(prevProps.isRowHovered, nextProps.isRowHovered) &&
-      equals(prevProps.row, nextProps.row)
+      equals(previousDisplayedComponentId, nextDisplayedComponentId) &&
+      equals(previousFormattedString, nextFormatttedString) &&
+      equals(previousColSpan, nextColSpan) &&
+      equals(previousTruncateCondition, nextTruncateCondition) &&
+      equals(previousHiddenCondition, nextHiddenCondition) &&
+      equals(previousHiddenCondition, nextHiddenCondition)
     );
   },
 );

--- a/src/Listing/ColumnCell.tsx
+++ b/src/Listing/ColumnCell.tsx
@@ -131,18 +131,22 @@ const ColumnCell = React.memo<Props>(
     const previousRow = prevProps.row;
     const previousIsRowHovered = prevProps.isRowHovered;
     const previousIsRowSelected = prevProps.isRowSelected;
+    const previousHasHoverableComponent = previousColumn.hasHoverableComponent;
+    const previousRenderComponentOnRowUpdate =
+      previousColumn.renderComponentOnRowUpdate;
 
     const nextColumn = nextProps.column;
     const nextRow = nextProps.row;
     const nextIsRowHovered = nextProps.isRowHovered;
     const nextIsRowSelected = nextProps.isRowSelected;
+    const nextHasHoverableComponent = nextColumn.hasHoverableComponent;
+    const nextRenderComponentOnRowUpdate =
+      nextColumn.renderComponentOnRowUpdate;
 
-    const previousDisplayedComponentId = previousColumn.getDisplayedComponentId?.(
-      previousIsRowHovered,
-    );
-    const nextDisplayedComponentId = nextColumn.getDisplayedComponentId?.(
-      nextIsRowHovered,
-    );
+    const previousIsComponentHovered =
+      previousHasHoverableComponent && previousIsRowHovered;
+    const nextIsComponentHovered =
+      nextHasHoverableComponent && nextIsRowHovered;
 
     const previousFormattedString = previousColumn.getFormattedString?.(
       previousRow,
@@ -167,12 +171,16 @@ const ColumnCell = React.memo<Props>(
     );
 
     return (
-      equals(previousDisplayedComponentId, nextDisplayedComponentId) &&
+      equals(previousIsComponentHovered, nextIsComponentHovered) &&
       equals(previousFormattedString, nextFormatttedString) &&
       equals(previousColSpan, nextColSpan) &&
       equals(previousTruncateCondition, nextTruncateCondition) &&
       equals(previousHiddenCondition, nextHiddenCondition) &&
-      equals(previousHiddenCondition, nextHiddenCondition)
+      equals(previousHiddenCondition, nextHiddenCondition) &&
+      equals(
+        previousRenderComponentOnRowUpdate && previousRow,
+        nextRenderComponentOnRowUpdate && nextRow,
+      )
     );
   },
 );

--- a/src/Listing/ColumnCell.tsx
+++ b/src/Listing/ColumnCell.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable react/prop-types */
-
 import * as React from 'react';
 
 import { equals } from 'ramda';
+import clsx from 'clsx';
 
 import {
   makeStyles,
@@ -12,7 +11,6 @@ import {
   Typography,
 } from '@material-ui/core';
 
-import clsx from 'clsx';
 import { Column, ColumnType, ComponentColumnProps } from './models';
 
 const BodyTableCell = withStyles((theme) => ({
@@ -44,88 +42,90 @@ interface Props {
   isRowHovered: boolean;
 }
 
-const ColumnCell = React.memo<Props>(
-  ({
-    row,
-    column,
-    listingCheckable,
-    isRowSelected,
-    isRowHovered,
-  }: Props): JSX.Element | null => {
-    const classes = useStyles(listingCheckable);
+const ColumnCell = ({
+  row,
+  column,
+  listingCheckable,
+  isRowSelected,
+  isRowHovered,
+}: Props): JSX.Element | null => {
+  const classes = useStyles(listingCheckable);
 
-    const cellByColumnType = {
-      [ColumnType.string]: (): JSX.Element => {
-        const {
-          getFormattedString,
-          width,
-          getTruncateCondition,
-          getColSpan,
-        } = column;
+  const cellByColumnType = {
+    [ColumnType.string]: (): JSX.Element => {
+      const {
+        getFormattedString,
+        width,
+        getTruncateCondition,
+        getColSpan,
+      } = column;
 
-        const isTruncated = getTruncateCondition?.(isRowSelected);
-        const colSpan = getColSpan?.(isRowSelected);
+      const isTruncated = getTruncateCondition?.(isRowSelected);
+      const colSpan = getColSpan?.(isRowSelected);
 
-        const formattedString = getFormattedString?.(row) || '';
+      const formattedString = getFormattedString?.(row) || '';
 
-        return (
-          <BodyTableCell
-            align="left"
-            style={{ width: width || 'auto' }}
-            className={classes.cell}
-            colSpan={colSpan}
-          >
-            {isTruncated && (
-              <Tooltip title={formattedString}>
-                <Typography
-                  variant="body2"
-                  className={clsx({ [classes.truncated]: isTruncated })}
-                >
-                  {formattedString}
-                </Typography>
-              </Tooltip>
-            )}
-            {!isTruncated && formattedString}
-          </BodyTableCell>
-        );
-      },
-      [ColumnType.component]: (): JSX.Element | null => {
-        const { getHiddenCondition, width, clickable } = column;
-        const Component = column.Component as (
-          props: ComponentColumnProps,
-        ) => JSX.Element;
+      return (
+        <BodyTableCell
+          align="left"
+          style={{ width: width || 'auto' }}
+          className={classes.cell}
+          colSpan={colSpan}
+        >
+          {isTruncated && (
+            <Tooltip title={formattedString}>
+              <Typography
+                variant="body2"
+                className={clsx({ [classes.truncated]: isTruncated })}
+              >
+                {formattedString}
+              </Typography>
+            </Tooltip>
+          )}
+          {!isTruncated && formattedString}
+        </BodyTableCell>
+      );
+    },
+    [ColumnType.component]: (): JSX.Element | null => {
+      const { getHiddenCondition, width, clickable } = column;
+      const Component = column.Component as (
+        props: ComponentColumnProps,
+      ) => JSX.Element;
 
-        const isCellHidden = getHiddenCondition?.(isRowSelected);
+      const isCellHidden = getHiddenCondition?.(isRowSelected);
 
-        if (isCellHidden) {
-          return null;
-        }
+      if (isCellHidden) {
+        return null;
+      }
 
-        return (
-          <BodyTableCell
-            align="left"
-            style={{ width: width || 'auto' }}
-            onClick={(e): void => {
-              if (!clickable) {
-                return;
-              }
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            className={classes.cell}
-          >
-            <Component
-              row={row}
-              isSelected={isRowSelected}
-              isHovered={isRowHovered}
-            />
-          </BodyTableCell>
-        );
-      },
-    };
+      return (
+        <BodyTableCell
+          align="left"
+          style={{ width: width || 'auto' }}
+          onClick={(e): void => {
+            if (!clickable) {
+              return;
+            }
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          className={classes.cell}
+        >
+          <Component
+            row={row}
+            isSelected={isRowSelected}
+            isHovered={isRowHovered}
+          />
+        </BodyTableCell>
+      );
+    },
+  };
 
-    return cellByColumnType[column.type]();
-  },
+  return cellByColumnType[column.type]();
+};
+
+const MemoizedColumnCell = React.memo<Props>(
+  ColumnCell,
   (prevProps, nextProps) => {
     const previousColumn = prevProps.column;
     const previousRow = prevProps.row;
@@ -185,5 +185,5 @@ const ColumnCell = React.memo<Props>(
   },
 );
 
-export default ColumnCell;
+export default MemoizedColumnCell;
 export { BodyTableCell, useStyles };

--- a/src/Listing/ColumnCell.tsx
+++ b/src/Listing/ColumnCell.tsx
@@ -1,0 +1,138 @@
+/* eslint-disable react/prop-types */
+
+import * as React from 'react';
+
+import { equals } from 'ramda';
+
+import {
+  makeStyles,
+  withStyles,
+  TableCell,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+
+import clsx from 'clsx';
+import { Column, ColumnType, ComponentColumnProps } from './models';
+
+const BodyTableCell = withStyles((theme) => ({
+  root: {
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    paddingRight: theme.spacing(0.5),
+  },
+}))(TableCell);
+
+const useStyles = makeStyles((theme) => ({
+  cell: {
+    paddingLeft: (listingCheckable: boolean): number =>
+      theme.spacing(listingCheckable ? 0 : 1.5),
+  },
+  truncated: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: 150,
+    whiteSpace: 'nowrap',
+  },
+}));
+
+interface Props {
+  row;
+  column: Column;
+  listingCheckable: boolean;
+  isRowSelected: boolean;
+  isRowHovered: boolean;
+}
+
+const ColumnCell = React.memo<Props>(
+  ({
+    row,
+    column,
+    listingCheckable,
+    isRowSelected,
+    isRowHovered,
+  }: Props): JSX.Element | null => {
+    const classes = useStyles(listingCheckable);
+
+    const cellByColumnType = {
+      [ColumnType.string]: (): JSX.Element => {
+        const {
+          getFormattedString,
+          width,
+          getTruncateCondition,
+          getColSpan,
+        } = column;
+
+        const isTruncated = getTruncateCondition?.(isRowSelected);
+        const colSpan = getColSpan?.(isRowSelected);
+
+        const formattedString = getFormattedString?.(row) || '';
+
+        return (
+          <BodyTableCell
+            align="left"
+            style={{ width: width || 'auto' }}
+            className={classes.cell}
+            colSpan={colSpan}
+          >
+            {isTruncated && (
+              <Tooltip title={formattedString}>
+                <Typography
+                  variant="body2"
+                  className={clsx({ [classes.truncated]: isTruncated })}
+                >
+                  {formattedString}
+                </Typography>
+              </Tooltip>
+            )}
+            {!isTruncated && formattedString}
+          </BodyTableCell>
+        );
+      },
+      [ColumnType.component]: (): JSX.Element | null => {
+        const { getHiddenCondition, width, clickable } = column;
+        const Component = column.Component as (
+          props: ComponentColumnProps,
+        ) => JSX.Element;
+
+        const isCellHidden = getHiddenCondition?.(isRowSelected);
+
+        if (isCellHidden) {
+          return null;
+        }
+
+        return (
+          <BodyTableCell
+            align="left"
+            style={{ width: width || 'auto' }}
+            onClick={(e): void => {
+              if (!clickable) {
+                return;
+              }
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            className={classes.cell}
+          >
+            <Component
+              row={row}
+              isSelected={isRowSelected}
+              isHovered={isRowHovered}
+            />
+          </BodyTableCell>
+        );
+      },
+    };
+
+    return cellByColumnType[column.type]();
+  },
+  (prevProps, nextProps) => {
+    return (
+      equals(prevProps.isRowHovered, nextProps.isRowHovered) &&
+      equals(prevProps.row, nextProps.row)
+    );
+  },
+);
+
+export default ColumnCell;
+export { BodyTableCell, useStyles };

--- a/src/Listing/Header.tsx
+++ b/src/Listing/Header.tsx
@@ -8,8 +8,9 @@ import {
   withStyles,
   TableSortLabel,
   Typography,
-  makeStyles,
 } from '@material-ui/core';
+
+import { useStyles as useCellStyles } from './ColumnCell';
 
 const HeaderCell = withStyles((theme) => ({
   root: {
@@ -24,13 +25,6 @@ const HeaderTypography = withStyles({
     fontWeight: 'bold',
   },
 })(Typography);
-
-export const useCellStyles = makeStyles((theme) => ({
-  cell: {
-    paddingLeft: (checkable: boolean): number =>
-      theme.spacing(checkable ? 0 : 1.5),
-  },
-}));
 
 interface Props {
   onSelectAllClick: (event) => void;

--- a/src/Listing/models.ts
+++ b/src/Listing/models.ts
@@ -9,12 +9,13 @@ export interface Column {
   label: string;
   type: ColumnType;
   Component?: (props: ComponentColumnProps) => JSX.Element;
+  getDisplayedComponentId?: (isHovered) => number;
   clickable?: boolean;
   width?: number | string;
   getFormattedString?: (row) => string | null;
   getColSpan?: (isSelected) => number | undefined;
   getTruncateCondition?: (isSelected) => boolean;
-  getHiddenCondition?: (boolean) => boolean;
+  getHiddenCondition?: (isSelected) => boolean;
   disablePadding?: boolean;
   sortable?: boolean;
 }

--- a/src/Listing/models.ts
+++ b/src/Listing/models.ts
@@ -9,7 +9,7 @@ export interface Column {
   label: string;
   type: ColumnType;
   Component?: (props: ComponentColumnProps) => JSX.Element | null;
-  getDisplayedComponentId?: (isHovered) => number;
+  hasHoverableComponent?: boolean;
   clickable?: boolean;
   width?: number | string;
   getFormattedString?: (row) => string | null;
@@ -19,6 +19,7 @@ export interface Column {
   disablePadding?: boolean;
   sortable?: boolean;
   sortField?: string;
+  renderComponentOnRowUpdate?: boolean;
 }
 
 enum ColumnType {

--- a/src/Listing/models.ts
+++ b/src/Listing/models.ts
@@ -13,7 +13,8 @@ export interface Column {
   width?: number | string;
   getFormattedString?: (row) => string | null;
   getColSpan?: (isSelected) => number | undefined;
-  getTruncationState?: (isSelected) => boolean;
+  getTruncateCondition?: (isSelected) => boolean;
+  getHiddenCondition?: (boolean) => boolean;
   disablePadding?: boolean;
   sortable?: boolean;
 }

--- a/src/Listing/models.ts
+++ b/src/Listing/models.ts
@@ -8,7 +8,7 @@ export interface Column {
   id: string;
   label: string;
   type: ColumnType;
-  Component?: (props: ComponentColumnProps) => JSX.Element;
+  Component?: (props: ComponentColumnProps) => JSX.Element | null;
   getDisplayedComponentId?: (isHovered) => number;
   clickable?: boolean;
   width?: number | string;
@@ -18,6 +18,7 @@ export interface Column {
   getHiddenCondition?: (isSelected) => boolean;
   disablePadding?: boolean;
   sortable?: boolean;
+  sortField?: string;
 }
 
 enum ColumnType {


### PR DESCRIPTION
This is an attempt to fixe some lags appearing on columns containing hoverable Components with large listings. To do so, there is an extensive check on Props modification within the ColumnCell Component (which is now a standalone, memo Component). 

The Column models contains a few more properties necessary to make sure the Listing is still rendered correctly:

- hasHoverableComponent (boolean): indicates whether the column has a Component that changes when hovered. This is necessary to trigger a re-render when the mouse hovers the corresponding row
- renderComponentOnRowUpdate (boolean): indicates whether the (Component) column should re-render when the corresponding row (Entity) has changes. 