### PR TITLE
feat(buildListingEndpoint): Add "conditions" to buildListingEndpoint

### DIFF
--- a/src/api/buildListingEndpoint/index.test.ts
+++ b/src/api/buildListingEndpoint/index.test.ts
@@ -94,4 +94,28 @@ describe(buildListingEndpoint, () => {
       '&search={"$and":[{"h.status":{"$in":[1,2,3,4]}}]}',
     );
   });
+
+  it('build the listing endpoint with a "$and" search expression between the given conditions', () => {
+    const endpoint = buildListingEndpoint({
+      baseEndpoint,
+      parameters: {
+        ...parameters,
+        search: {
+          conditions: [
+            {
+              field: 'date',
+              values: {
+                $gt: '2020-12-01T07:00:00',
+                $lt: '2020-12-01T11:00:00',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(decodeURIComponent(endpoint)).toContain(
+      '&search={"$and":[{"date":{"$gt":"2020-12-01T07:00:00"}},{"date":{"$lt":"2020-12-01T11:00:00"}}]}',
+    );
+  });
 });

--- a/src/api/buildListingEndpoint/models.ts
+++ b/src/api/buildListingEndpoint/models.ts
@@ -22,6 +22,7 @@ export interface Parameters {
 export interface SearchParameter {
   regex?: RegexSearchParameter;
   lists?: Array<ListsSearchParameter>;
+  conditions?: Array<ConditionsSearchParameter>;
 }
 
 export interface ListsSearchQueryParameterValue {
@@ -40,6 +41,27 @@ export interface RegexSearchParameter {
 export interface ListsSearchParameter {
   field: string;
   values: Array<string | number>;
+}
+
+export type Operator =
+  | '$eq'
+  | '$neq'
+  | '$lt'
+  | '$le'
+  | '$gt'
+  | '$ge'
+  | '$lk'
+  | '$nk'
+  | '$in'
+  | '$ni';
+
+export type ConditionValue = {
+  [value in Operator]?: string;
+};
+
+export interface ConditionsSearchParameter {
+  field: string;
+  values: ConditionValue;
 }
 
 type SearchPatterns = Array<{ [field: string]: { $rg: string } }>;


### PR DESCRIPTION
This allows to pass some conditions to the buildListingEndpoint function like so: 

```
  it('build the listing endpoint with a "$and" search expression between the given conditions', () => {
    const endpoint = buildListingEndpoint({
      baseEndpoint,
      parameters: {
        ...parameters,
        search: {
          conditions: [
            {
              field: 'date',
              values: {
                $gt: '2020-12-01T07:00:00',
                $lt: '2020-12-01T11:00:00',
              },
            },
          ],
        },
      },
    });

    expect(decodeURIComponent(endpoint)).toContain(
      '&search={"$and":[{"date":{"$gt":"2020-12-01T07:00:00"}},{"date":{"$lt":"2020-12-01T11:00:00"}}]}',
    );
  });
```

supported conditions are:
```
  | '$eq'
  | '$neq'
  | '$lt'
  | '$le'
  | '$gt'
  | '$ge'
  | '$lk'
  | '$nk'
  | '$in'
  | '$ni';
```