### PR TITLE
fix(Listing): Remove labelDisplayedRows function from memo comparison

### DIFF
--- a/src/Listing/Pagination.tsx
+++ b/src/Listing/Pagination.tsx
@@ -24,7 +24,6 @@ const MemoizedPagination = React.memo(
     equals(prevProps.rowsPerPage, nextProps.rowsPerPage) &&
     equals(prevProps.page, nextProps.page) &&
     equals(prevProps.count, prevProps.count) &&
-    equals(prevProps.labelDisplayedRows, prevProps.labelDisplayedRows) &&
     equals(prevProps.labelRowsPerPage, prevProps.labelRowsPerPage),
 );
 

--- a/src/Listing/Pagination.tsx
+++ b/src/Listing/Pagination.tsx
@@ -23,8 +23,8 @@ const MemoizedPagination = React.memo(
   (prevProps, nextProps) =>
     equals(prevProps.rowsPerPage, nextProps.rowsPerPage) &&
     equals(prevProps.page, nextProps.page) &&
-    equals(prevProps.count, prevProps.count) &&
-    equals(prevProps.labelRowsPerPage, prevProps.labelRowsPerPage),
+    equals(prevProps.count, nextProps.count) &&
+    equals(prevProps.labelRowsPerPage, nextProps.labelRowsPerPage),
 );
 
 export default withStyles(styles)(MemoizedPagination);


### PR DESCRIPTION
As `labelDisplayedRows` is a function we shuld remove it from memo's comparison function