### PR TITLE
chore(ci): use discoverGitReferenceBuild instead of reference build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,11 +34,11 @@ try {
       sh 'setup_centreon_build.sh'
       sh "./centreon-build/jobs/ui/${serie}/ui-unittest.sh"
       junit 'ut.xml'
+      discoverGitReferenceBuild()
       recordIssues(
         enabledForFailure: true,
         failOnError: true,
         tools: [esLint(pattern: 'codestyle.xml')],
-        referenceJobName: 'centreon-ui/master'
       )
       archiveArtifacts allowEmptyArchive: true, artifacts: 'snapshots/*.png'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,12 +34,15 @@ try {
       sh 'setup_centreon_build.sh'
       sh "./centreon-build/jobs/ui/${serie}/ui-unittest.sh"
       junit 'ut.xml'
+
       discoverGitReferenceBuild()
       recordIssues(
         enabledForFailure: true,
         failOnError: true,
         tools: [esLint(pattern: 'codestyle.xml')],
+        trendChartType: 'NONE'
       )
+
       archiveArtifacts allowEmptyArchive: true, artifacts: 'snapshots/*.png'
     }
     if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {


### PR DESCRIPTION
## Description

use discoverGitReferenceBuild instead of manually set reference build
this is needed by new warning ng plugin version

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI