### PR TITLE
enh(chore): Update eslintrc config to use new config from frontend-core

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  extends: './node_modules/@centreon/frontend-core/eslint/typescript',
+  extends:
+    './node_modules/@centreon/frontend-core/eslint/react/typescript.eslintrc.js',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,7 +1215,7 @@
       "dev": true
     },
     "@centreon/frontend-core": {
-      "version": "github:centreon/frontend-core#1d8d7c3affd2aa79d787fb4221d73bda55a8fb67",
+      "version": "github:centreon/frontend-core#146210738014091f19d630938be24ee3ea9692ae",
       "from": "github:centreon/frontend-core",
       "dev": true
     },
@@ -6862,6 +6862,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -10448,6 +10458,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -10716,6 +10733,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -13922,6 +13940,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -22299,6 +22318,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }


### PR DESCRIPTION
## Description

Updating eslint config file to use last version from frontend-core module.
This allow to use modular eslint config file for differents envirements ( node, react ...)

Fix : (DEVOPS-206)

## Type of change

- [ x ] New functionality (non-breaking change)

## Target serie

- [ x ] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

just normally run eslint, and it should be working without any issue

``` npm run eslint ```
