### PR TITLE
fix(search): fix regex to get search parameters

### DIFF
--- a/src/api/buildListingEndpoint/getSearchQueryParameterValue.ts
+++ b/src/api/buildListingEndpoint/getSearchQueryParameterValue.ts
@@ -25,7 +25,7 @@ const getFoundFields = ({
   fields,
 }: RegexSearchParameter): Array<SearchMatch> => {
   const fieldMatches = fields.map((field) => {
-    const pattern = `${field.replace('.', '\\.')}:([^\\s]+)`;
+    const pattern = `(?:^|\\s)${field.replace('.', '\\.')}:([^\\s]+)`;
 
     const [, valueMatch] = value?.match(pattern) || [];
 


### PR DESCRIPTION
Start of fieldname was not properly matched.
It should be detected by the line start, or by a space before