### PR TITLE
Fix(Listing): Reduce Listing freeze

### DIFF
--- a/src/Listing/Cell/DataCell.tsx
+++ b/src/Listing/Cell/DataCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { equals } from 'ramda';
+import { equals, props } from 'ramda';
 
 import { makeStyles, Tooltip, Typography, Theme } from '@material-ui/core';
 
@@ -134,6 +134,7 @@ const MemoizedDataCell = React.memo<Props>(
     const previousRenderComponentCondition = previousColumn.getRenderComponentCondition?.(
       previousRow,
     );
+    const previousRowMemoProps = previousColumn.rowMemoProps;
     const previousIsComponentHovered =
       previousHasHoverableComponent && previousIsRowHovered;
     const previousFormattedString = previousColumn.getFormattedString?.(
@@ -159,10 +160,11 @@ const MemoizedDataCell = React.memo<Props>(
     const nextRenderComponentCondition = nextColumn.getRenderComponentCondition?.(
       nextRow,
     );
+    const nextRowMemoProps = nextColumn.rowMemoProps;
     const nextIsComponentHovered =
       nextHasHoverableComponent && nextIsRowHovered;
 
-    const nextFormatttedString = nextColumn.getFormattedString?.(nextRow);
+    const nextFormattedString = nextColumn.getFormattedString?.(nextRow);
 
     const nextColSpan = nextColumn.getColSpan?.(nextIsRowSelected);
 
@@ -188,18 +190,28 @@ const MemoizedDataCell = React.memo<Props>(
       return true;
     }
 
+    const previousRowProps = previousRowMemoProps
+      ? props(previousRowMemoProps, previousRow)
+      : previousRow;
+    const nextRowProps = nextRowMemoProps
+      ? props(nextRowMemoProps, nextRow)
+      : nextRow;
+
     return (
       equals(previousIsComponentHovered, nextIsComponentHovered) &&
       equals(previousIsRowHovered, nextIsRowHovered) &&
-      equals(previousFormattedString, nextFormatttedString) &&
+      equals(previousFormattedString, nextFormattedString) &&
       equals(previousColSpan, nextColSpan) &&
       equals(previousIsTruncated, nextIsTruncated) &&
       equals(previousHiddenCondition, nextHiddenCondition) &&
       equals(
-        previousRenderComponentOnRowUpdate && previousRow,
-        nextRenderComponentOnRowUpdate && nextRow,
+        previousRenderComponentOnRowUpdate && previousRowProps,
+        nextRenderComponentOnRowUpdate && nextRowProps,
       ) &&
-      equals(previousRow, nextRow) &&
+      equals(
+        previousFormattedString ?? previousRowProps,
+        nextFormattedString ?? nextRowProps,
+      ) &&
       equals(prevRowColors, nextRowColors)
     );
   },

--- a/src/Listing/Header/index.tsx
+++ b/src/Listing/Header/index.tsx
@@ -1,6 +1,17 @@
 import * as React from 'react';
 
-import { equals, find, indexOf, isNil, move, path, prop, propEq } from 'ramda';
+import {
+  equals,
+  find,
+  indexOf,
+  isNil,
+  map,
+  move,
+  path,
+  pick,
+  prop,
+  propEq,
+} from 'ramda';
 import {
   DndContext,
   DragOverlay,
@@ -115,6 +126,7 @@ const ListingHeader = ({
   const getColumnById = (id: string): Column => {
     return find(propEq('id', id), columns) as Column;
   };
+
   return (
     <DndContext
       sensors={sensors}
@@ -164,6 +176,15 @@ const ListingHeader = ({
   );
 };
 
+const columnMemoProps = [
+  'id',
+  'label',
+  'rowMemoProps',
+  'sortField',
+  'sortable',
+  'type',
+];
+
 const MemoizedListingHeader = React.memo(
   ListingHeader,
   (prevProps, nextProps) =>
@@ -171,7 +192,10 @@ const MemoizedListingHeader = React.memo(
     equals(prevProps.sortField, nextProps.sortField) &&
     equals(prevProps.selectedRowCount, nextProps.selectedRowCount) &&
     equals(prevProps.rowCount, nextProps.rowCount) &&
-    equals(prevProps.columns, nextProps.columns) &&
+    equals(
+      map(pick(columnMemoProps), prevProps.columns),
+      map(pick(columnMemoProps), nextProps.columns),
+    ) &&
     equals(prevProps.checkable, nextProps.checkable) &&
     equals(prevProps.columnConfiguration, nextProps.columnConfiguration),
 );

--- a/src/Listing/Row.tsx
+++ b/src/Listing/Row.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { equals, length, not, pluck } from 'ramda';
+import { equals, not, pluck } from 'ramda';
 
 import { TableRowProps, TableRow, makeStyles, Theme } from '@material-ui/core';
 

--- a/src/Listing/Row.tsx
+++ b/src/Listing/Row.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { equals, not } from 'ramda';
+import { equals, length, not, pluck } from 'ramda';
 
 import { TableRowProps, TableRow, makeStyles, Theme } from '@material-ui/core';
 
@@ -80,7 +80,14 @@ const Row = React.memo<RowProps>(
       visibleColumns: nextVisibleColumns,
     } = nextProps;
 
-    if (not(equals(previousVisibleColumns, nextVisibleColumns))) {
+    if (
+      not(
+        equals(
+          pluck('id', previousVisibleColumns),
+          pluck('id', nextVisibleColumns),
+        ),
+      )
+    ) {
       return false;
     }
 
@@ -112,9 +119,11 @@ const IntersectionRow = (props: Props): JSX.Element => {
   const { isInViewport, setElement } = useViewportIntersection();
   const classes = useStyles();
 
+  const getFirstCellElement = () => rowRef.current?.firstChild?.firstChild;
+
   React.useEffect(() => {
-    setElement(rowRef.current?.firstChild?.firstChild as HTMLDivElement);
-  }, [rowRef.current?.firstChild?.firstChild]);
+    setElement(getFirstCellElement() as HTMLDivElement);
+  }, [getFirstCellElement()]);
 
   return (
     <div className={classes.intersectionRow} ref={rowRef}>

--- a/src/Listing/Row.tsx
+++ b/src/Listing/Row.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { equals, not } from 'ramda';
 
 import { TableRowProps, TableRow, makeStyles, Theme } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
 
 import { useViewportIntersection } from '../utils/useViewportIntersection';
 
@@ -52,20 +51,8 @@ const Row = React.memo<RowProps>(
     onMouseOver,
     onFocus,
     onClick,
-    isInViewport,
-    visibleColumns,
   }: RowProps): JSX.Element => {
     const classes = useStyles();
-
-    if (not(isInViewport)) {
-      return (
-        <>
-          {visibleColumns.map(({ id }) => (
-            <Skeleton className={classes.skeleton} key={id} variant="rect" />
-          ))}
-        </>
-      );
-    }
 
     return (
       <TableRow
@@ -84,12 +71,18 @@ const Row = React.memo<RowProps>(
     const {
       row: previousRow,
       rowColorConditions: previousRowColorConditions,
+      visibleColumns: previousVisibleColumns,
     } = prevProps;
     const {
       row: nextRow,
       rowColorConditions: nextRowColorConditions,
       isInViewport: nextIsInViewport,
+      visibleColumns: nextVisibleColumns,
     } = nextProps;
+
+    if (not(equals(previousVisibleColumns, nextVisibleColumns))) {
+      return false;
+    }
 
     if (not(nextIsInViewport)) {
       return true;

--- a/src/Listing/index.tsx
+++ b/src/Listing/index.tsx
@@ -242,6 +242,11 @@ const Listing = <TRow extends { id: RowId }>({
     return `${checkbox}${columnTemplate}`;
   };
 
+  const visibleColumns = getVisibleColumns({
+    columnConfiguration,
+    columns,
+  });
+
   return (
     <>
       {loading && rows.length > 0 && (
@@ -321,6 +326,7 @@ const Listing = <TRow extends { id: RowId }>({
                     row={row}
                     rowColorConditions={rowColorConditions}
                     tabIndex={-1}
+                    visibleColumns={visibleColumns}
                     onClick={(): void => {
                       onRowClick(row);
                     }}
@@ -345,10 +351,7 @@ const Listing = <TRow extends { id: RowId }>({
                       </Cell>
                     )}
 
-                    {getVisibleColumns({
-                      columnConfiguration,
-                      columns,
-                    }).map((column) => (
+                    {visibleColumns.map((column) => (
                       <DataCell
                         column={column}
                         isRowHovered={isRowHovered}

--- a/src/Listing/models.ts
+++ b/src/Listing/models.ts
@@ -18,6 +18,7 @@ export interface Column {
   id: string;
   isTruncated?: boolean;
   label: string;
+  rowMemoProps?: Array<string>;
   sortField?: string;
   sortable?: boolean;
   type: ColumnType;

--- a/src/utils/useViewportIntersection.ts
+++ b/src/utils/useViewportIntersection.ts
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+interface GraphIntersectionState {
+  isInViewport: boolean;
+  setElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
+}
+
+export const useViewportIntersection = (): GraphIntersectionState => {
+  const [entry, setEntry] = React.useState<IntersectionObserverEntry | null>(
+    null,
+  );
+  const [element, setElement] = React.useState<HTMLElement | null>(null);
+
+  const observer = React.useRef<IntersectionObserver | null>(null);
+
+  React.useEffect(() => {
+    if (observer.current) {
+      observer.current.disconnect();
+    }
+
+    observer.current = new window.IntersectionObserver(([newEntry]) =>
+      setEntry(newEntry),
+    );
+
+    if (element) {
+      observer.current.observe(element);
+    }
+
+    return () => {
+      observer.current?.disconnect();
+    };
+  }, [element]);
+
+  return {
+    isInViewport: entry?.isIntersecting ?? true,
+    setElement,
+  };
+};

--- a/src/utils/useViewportIntersection.ts
+++ b/src/utils/useViewportIntersection.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-interface GraphIntersectionState {
+interface ViewportIntersectionState {
   isInViewport: boolean;
   setElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
 }
 
-export const useViewportIntersection = (): GraphIntersectionState => {
+export const useViewportIntersection = (): ViewportIntersectionState => {
   const [entry, setEntry] = React.useState<IntersectionObserverEntry | null>(
     null,
   );


### PR DESCRIPTION
This reduces listing freeze by improving the DataCell memoization and not re-render the rows which are not in the viewport.

Before: For 100 elements on Resource Status, it took ~650ms  to render the Listing component
Now: It take ~30ms to render the Listing component